### PR TITLE
Loading time improvements

### DIFF
--- a/src/api/details.ts
+++ b/src/api/details.ts
@@ -1,4 +1,4 @@
-import { Settings, getMapSettings } from './settings';
+import { getDetailsUrl } from './settings';
 
 async function fetchDetails(url: string) {
   const res = await fetch(`${process.env.apiHost}${url}`, {
@@ -11,18 +11,14 @@ async function fetchDetails(url: string) {
 }
 
 export async function getDetails(path: string, id: number) {
-  let settings = null;
+  let endpoint = '';
   try {
-    settings = (await getMapSettings()) as Settings['map'];
+    endpoint = await getDetailsUrl(path);
   } catch (error) {
     // notfound
     return null;
   }
-  const { url: endpoint } =
-    settings.layersTree
-      .flatMap(({ layers }) => layers)
-      .find(item => item.type === path) ?? {};
-  if (endpoint === undefined) {
+  if (endpoint === '') {
     return null;
   }
   let details = null;

--- a/src/api/fullsettings.ts
+++ b/src/api/fullsettings.ts
@@ -1,39 +1,39 @@
-import { getLocalettings } from "./localSettings";
-import { Settings, fetchSettings } from "./settings";
+import { getLocalettings } from './localSettings';
+import { Settings, fetchSettings } from './settings';
 
 export async function getSettings(): Promise<Settings | null> {
-    let rawSettings = null;
-    let customization = null;
-    try {
-      rawSettings = await fetchSettings();
-      customization = await getLocalettings();
-    } catch (error) {
-      throw error;
-    }
-    const {
-      map: {
-        baseLayers,
-        group,
-        bounds: [lat1, lng1, lat2, lng2],
-      },
-      flatpages,
-      ...settings
-    } = rawSettings;
-    return {
-      customization: {
-        ...settings,
-        ...customization,
-      },
-      flatpages,
-      map: {
-        baseLayers,
-        layersTree: group,
-        container: {
-          bounds: [
-            [lng1, lat1],
-            [lng2, lat2],
-          ],
-        },
-      },
-    };
+  let rawSettings = null;
+  let customization = null;
+  try {
+    rawSettings = await fetchSettings();
+    customization = await getLocalettings();
+  } catch (error) {
+    throw error;
   }
+  const {
+    map: {
+      baseLayers,
+      group,
+      bounds: [lat1, lng1, lat2, lng2],
+    },
+    flatpages,
+    ...settings
+  } = rawSettings;
+  return {
+    customization: {
+      ...settings,
+      ...customization,
+    },
+    flatpages,
+    map: {
+      baseLayers,
+      layersTree: group,
+      container: {
+        bounds: [
+          [lng1, lat1],
+          [lng2, lat2],
+        ],
+      },
+    },
+  };
+}

--- a/src/api/fullsettings.ts
+++ b/src/api/fullsettings.ts
@@ -1,0 +1,39 @@
+import { getLocalettings } from "./localSettings";
+import { Settings, fetchSettings } from "./settings";
+
+export async function getSettings(): Promise<Settings | null> {
+    let rawSettings = null;
+    let customization = null;
+    try {
+      rawSettings = await fetchSettings();
+      customization = await getLocalettings();
+    } catch (error) {
+      throw error;
+    }
+    const {
+      map: {
+        baseLayers,
+        group,
+        bounds: [lat1, lng1, lat2, lng2],
+      },
+      flatpages,
+      ...settings
+    } = rawSettings;
+    return {
+      customization: {
+        ...settings,
+        ...customization,
+      },
+      flatpages,
+      map: {
+        baseLayers,
+        layersTree: group,
+        container: {
+          bounds: [
+            [lng1, lat1],
+            [lng2, lat2],
+          ],
+        },
+      },
+    };
+  }

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -3,7 +3,6 @@ import { FeatureCollection } from 'geojson';
 import { GeoJSONOptions, LatLngBoundsExpression } from 'leaflet';
 import slugify from 'slugify';
 
-
 export type Attachement = { thumbnail: string; url: string; title: string };
 
 type BaseLayers = {

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import { notFound } from 'next/navigation';
-import { getMenuSettings, getSettings } from '@/api/settings';
+import { getMenuSettings } from '@/api/settings';
+import { getSettings } from '@/api/fullsettings';
 import { SettingsContextProvider } from '@/context/settings';
 import { NextIntlClientProvider, useLocale } from 'next-intl';
 import { getTranslations } from 'next-intl/server';

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { notFound } from 'next/navigation';
-import { getMenuSettings } from '@/api/settings';
 import { getSettings } from '@/api/fullsettings';
+import { getMenuSettings } from '@/api/settings';
 import { SettingsContextProvider } from '@/context/settings';
 import { NextIntlClientProvider, useLocale } from 'next-intl';
 import { getTranslations } from 'next-intl/server';

--- a/src/app/[locale]/map/[details]/[id]/loading.tsx
+++ b/src/app/[locale]/map/[details]/[id]/loading.tsx
@@ -1,5 +1,5 @@
-import { Icons } from "@/components/icons";
+import { Icons } from '@/components/icons';
 
 export default function Loading() {
-    return <Icons.loading className="animate-spin text-primary h-8 w-8 m-auto" />;
-  }
+  return <Icons.loading className="m-auto h-8 w-8 animate-spin text-primary" />;
+}

--- a/src/app/[locale]/map/[details]/[id]/loading.tsx
+++ b/src/app/[locale]/map/[details]/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { Icons } from "@/components/icons";
+
+export default function Loading() {
+    return <Icons.loading className="animate-spin text-primary h-8 w-8 m-auto" />;
+  }

--- a/src/app/[locale]/map/[details]/[id]/loading.tsx
+++ b/src/app/[locale]/map/[details]/[id]/loading.tsx
@@ -1,5 +1,14 @@
+import { useTranslations } from 'next-intl';
+
 import { Icons } from '@/components/icons';
 
 export default function Loading() {
-  return <Icons.loading className="m-auto h-8 w-8 animate-spin text-primary" />;
+  const t = useTranslations();
+  return (
+    <Icons.loading
+      className="m-auto h-8 w-8 animate-spin text-primary"
+      role="img"
+      aria-label={t('site.loading')}
+    />
+  );
 }

--- a/src/app/[locale]/map/layout.tsx
+++ b/src/app/[locale]/map/layout.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from 'react';
-import { Settings, getMapSettings } from '@/api/settings';
 import { MapContextProvider } from '@/context/map';
 import { getTranslations } from 'next-intl/server';
 
@@ -20,16 +19,8 @@ export const generateMetadata = async () => {
 };
 
 export default async function MapLayout({ children }: Props) {
-  let settings = null;
-
-  try {
-    settings = (await getMapSettings()) as Settings['map'];
-  } catch (error) {
-    throw error;
-  }
-
   return (
-    <MapContextProvider defaultSettings={settings}>
+    <MapContextProvider>
       <main
         role="main"
         className="grid h-full w-screen grid-cols-[100dvw_auto_100dvw] grid-rows-1 justify-stretch overflow-x-hidden scroll-smooth md:grid-cols-[50dvw_auto_50dvw] lg:grid-cols-[300px_auto_1fr]"

--- a/src/app/[locale]/page/[slug]/layout.tsx
+++ b/src/app/[locale]/page/[slug]/layout.tsx
@@ -17,7 +17,6 @@ type GenerateMetaDataProps = {
 export const generateMetadata = async ({
   params: { slug },
 }: GenerateMetaDataProps) => {
-  const t = await getTranslations('site');
   const content = await getPage(slug);
   if (content === null) {
     return;

--- a/src/components/map-filters.tsx
+++ b/src/components/map-filters.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useMapContext } from '@/context/map';
+import { useTranslations } from 'next-intl';
 
 import { partition } from '@/lib/utils';
 import {
@@ -14,6 +15,7 @@ import { Switch } from './ui/switch';
 
 export default function MapFilters() {
   const { settings, layers, toggleLayer } = useMapContext();
+  const t = useTranslations();
 
   const handleChange = useCallback(
     (id: number, isActive: boolean) => {
@@ -29,7 +31,8 @@ export default function MapFilters() {
   ) {
     return (
       <div className="bg-background px-3">
-        {Array.from({ length: 4 }).map(() => (
+        <p className="sr-only">{t('site.loading')}</p>
+        {Array.from({ length: 4 }, () => (
           <div className="flex w-full justify-between border-b py-4 last:border-b-0">
             <div className="skeleton-animation h-6 w-32 rounded"></div>
             <div className="skeleton-animation h-6 w-12 rounded-xl"></div>

--- a/src/components/map-filters.tsx
+++ b/src/components/map-filters.tsx
@@ -30,9 +30,9 @@ export default function MapFilters() {
     return (
       <div className="bg-background px-3">
         {Array.from({ length: 4 }).map(() => (
-          <div className="w-full flex justify-between border-b last:border-b-0 py-4">
-            <div className="w-32 h-6 rounded skeleton-animation"></div>
-            <div className="w-12 h-6 rounded-xl skeleton-animation"></div>
+          <div className="flex w-full justify-between border-b py-4 last:border-b-0">
+            <div className="skeleton-animation h-6 w-32 rounded"></div>
+            <div className="skeleton-animation h-6 w-12 rounded-xl"></div>
           </div>
         ))}
       </div>

--- a/src/components/map-filters.tsx
+++ b/src/components/map-filters.tsx
@@ -1,8 +1,7 @@
 import { useCallback } from 'react';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useMapContext } from '@/context/map';
 
-import { getUrlSearchParamsForLayers, partition } from '@/lib/utils';
+import { partition } from '@/lib/utils';
 import {
   Accordion,
   AccordionContent,
@@ -14,29 +13,30 @@ import { Label } from './ui/label';
 import { Switch } from './ui/switch';
 
 export default function MapFilters() {
-  const { settings } = useMapContext();
-  const router = useRouter();
-  const pathname = usePathname();
-  const params = useSearchParams();
-  const layersFromParams = params.get('layers') ?? '';
+  const { settings, layers, toggleLayer } = useMapContext();
 
   const handleChange = useCallback(
     (id: number, isActive: boolean) => {
-      const nextLayerSearchParams = getUrlSearchParamsForLayers(
-        layersFromParams,
-        [id],
-        isActive,
-      );
-      const textFromParams = params.get('text')
-        ? `&text=${params.get('text')}`
-        : '';
-      router.push(`${pathname}${nextLayerSearchParams}${textFromParams}`);
+      toggleLayer(id, isActive);
     },
-    [layersFromParams, params, router, pathname],
+    [toggleLayer],
   );
 
-  if (settings === null || settings.layersTree.length === 0) {
-    return null;
+  if (
+    settings === null ||
+    settings.layersTree.length === 0 ||
+    layers === null
+  ) {
+    return (
+      <div className="bg-background px-3">
+        {Array.from({ length: 4 }).map(() => (
+          <div className="w-full flex justify-between border-b last:border-b-0 py-4">
+            <div className="w-32 h-6 rounded skeleton-animation"></div>
+            <div className="w-12 h-6 rounded-xl skeleton-animation"></div>
+          </div>
+        ))}
+      </div>
+    );
   }
 
   const [grouped, [notGrouped]] = partition(
@@ -44,10 +44,9 @@ export default function MapFilters() {
     layer => layer.label !== null,
   );
 
-  const defaultActivatedLayers = layersFromParams
-    .split(',')
-    .filter(Boolean)
-    .map(Number);
+  const activatedLayers = layers
+    .filter(({ isActive }) => isActive)
+    .map(({ id }) => id);
 
   return (
     <>
@@ -75,7 +74,11 @@ export default function MapFilters() {
                       </Label>
                       <Switch
                         id={`layerItem-${layer.id}`}
-                        checked={defaultActivatedLayers.includes(layer.id)}
+                        checked={activatedLayers.includes(layer.id)}
+                        isLoading={
+                          !layers.find(e => e.id === layer.id)?.geojson &&
+                          activatedLayers.includes(layer.id)
+                        }
                         onCheckedChange={isActive =>
                           handleChange(layer.id, isActive)
                         }
@@ -100,7 +103,11 @@ export default function MapFilters() {
               </Label>
               <Switch
                 id={`layerItem-${layer.id}`}
-                checked={defaultActivatedLayers.includes(layer.id)}
+                checked={activatedLayers.includes(layer.id)}
+                isLoading={
+                  !layers.find(e => e.id === layer.id)?.geojson &&
+                  activatedLayers.includes(layer.id)
+                }
                 onCheckedChange={isActive => handleChange(layer.id, isActive)}
               />
             </li>

--- a/src/components/metadata-list.tsx
+++ b/src/components/metadata-list.tsx
@@ -45,7 +45,7 @@ const MetadataItem = ({
     <div className="flex flex-row flex-wrap items-center justify-center gap-1">
       <dt>
         <Icon
-          className={cn('text-primary', small && 'w-4 h-4')}
+          className={cn('text-primary', small && 'h-4 w-4')}
           {...propsForSVGPresentation}
         />
         <span className="sr-only">{t(type)}</span>

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -9,7 +9,9 @@ import { Icons } from '../icons';
 
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> & { isLoading?: boolean }
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> & {
+    isLoading?: boolean;
+  }
 >(({ className, isLoading, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
@@ -25,7 +27,7 @@ const Switch = React.forwardRef<
       )}
     >
       {isLoading && (
-        <Icons.loading className="animate-spin text-primary w-full h-full" />
+        <Icons.loading className="h-full w-full animate-spin text-primary" />
       )}
     </SwitchPrimitives.Thumb>
   </SwitchPrimitives.Root>

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import * as SwitchPrimitives from '@radix-ui/react-switch';
+import { useTranslations } from 'next-intl';
 
 import { cn } from '@/lib/utils';
 
@@ -12,26 +13,33 @@ const Switch = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> & {
     isLoading?: boolean;
   }
->(({ className, isLoading, ...props }, ref) => (
-  <SwitchPrimitives.Root
-    className={cn(
-      'peer inline-flex h-[24px] w-[44px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
-      className,
-    )}
-    {...props}
-    ref={ref}
-  >
-    <SwitchPrimitives.Thumb
+>(({ className, isLoading, ...props }, ref) => {
+  const t = useTranslations();
+  return (
+    <SwitchPrimitives.Root
       className={cn(
-        'pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0',
+        'peer inline-flex h-[24px] w-[44px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+        className,
       )}
+      {...props}
+      ref={ref}
     >
-      {isLoading && (
-        <Icons.loading className="h-full w-full animate-spin text-primary" />
-      )}
-    </SwitchPrimitives.Thumb>
-  </SwitchPrimitives.Root>
-));
+      <SwitchPrimitives.Thumb
+        className={cn(
+          'pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0',
+        )}
+      >
+        {isLoading && (
+          <Icons.loading
+            className="h-full w-full animate-spin text-primary"
+            role="img"
+            aria-label={t('site.loading')}
+          />
+        )}
+      </SwitchPrimitives.Thumb>
+    </SwitchPrimitives.Root>
+  );
+});
 Switch.displayName = SwitchPrimitives.Root.displayName;
 
 export { Switch };

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -5,10 +5,12 @@ import * as SwitchPrimitives from '@radix-ui/react-switch';
 
 import { cn } from '@/lib/utils';
 
+import { Icons } from '../icons';
+
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> & { isLoading?: boolean }
+>(({ className, isLoading, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
       'peer inline-flex h-[24px] w-[44px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
@@ -21,7 +23,11 @@ const Switch = React.forwardRef<
       className={cn(
         'pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0',
       )}
-    />
+    >
+      {isLoading && (
+        <Icons.loading className="animate-spin text-primary w-full h-full" />
+      )}
+    </SwitchPrimitives.Thumb>
   </SwitchPrimitives.Root>
 ));
 Switch.displayName = SwitchPrimitives.Root.displayName;

--- a/src/context/map.tsx
+++ b/src/context/map.tsx
@@ -14,7 +14,6 @@ import { Layer, Settings, getMapSettings } from '@/api/settings';
 import { FeatureCollection, Point } from 'geojson';
 import { Map } from 'leaflet';
 
-
 type MapContextProps = {
   layers: Layer[] | null;
   map: Map | null;
@@ -82,7 +81,7 @@ export const MapContextProvider = ({ children }: MapContextProviderProps) => {
           null,
       );
     }
-  }, [settings]);
+  }, [settings, layersFromParams]);
 
   const [map, setMap] = useState<Map | null>(null);
   const [observationCoordinates, setObservationCoordinates] =
@@ -165,7 +164,7 @@ export const MapContextProvider = ({ children }: MapContextProviderProps) => {
       '',
       `${nextLayerSearchParams}${textFromParams}`,
     );
-  }, [layers, params.get('text')]);
+  }, [layers, params]);
 
   return (
     <MapContext.Provider

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -132,3 +132,23 @@ just hide all tooltips that aren't the last one
 .leaflet-tooltip-pane > .leaflet-tooltip:not(:last-child) {
   display: none;
 }
+
+
+.skeleton-animation {
+  background: linear-gradient(90deg, hsl(var(--muted-foreground)) 0%, hsl(var(--foreground)) 50%, hsl(var(--muted-foreground)) 100%);
+  background-size: 300% 100%;
+  opacity: 0.2;
+  animation: skeletonator 4s ease infinite;
+}
+
+@keyframes skeletonator {
+  0% {
+    background-position-x: 0%;
+  }
+  50% {
+    background-position-x: 100%;
+  }
+  100% {
+    background-position-x: 0%;
+  }
+}

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -86,7 +86,8 @@
     "menu": "Menu",
     "openMenu": "Ouvrir le menu",
     "prev": "Précédent",
-    "next": "Suivant"
+    "next": "Suivant",
+    "loading": "Chargement"
   },
   "theme": {
     "toggle": "Thème {theme}",


### PR DESCRIPTION
**All loadings of the app have been significantly reduced :**
  - Limited number of requests made on each actions, only make request if necessary for the next UI change
  - GeoJSON files are now fetched separetely from the settings and the list of layers, meaning the UI is usable while the files are still fetched
  - Activating / deactivating a layer changes the state of the switch instantly, the timing of side-effects don't affect it
  - MapContext fetches settings itself, meaning the UI can render before the request is finished
 
**Loading indicators on some UI elements :**
  - Map is rendered as soon as possible, the sidebar has "skeleton" layers while waiting for the settings to be fetched
  - When a layer is activated but its GeoJSON is still loading, the switch displays a loader
  - Details page has a spinner


**Results :**
Clicking on "streams" from the homepage

Before : 6 seconds until usable UI and map, with streams displayed
Now : < 1 second until usable UI and map, streams are displayed at 6 seconds

Clicking on a river on the map 

Before : 6 seconds until details are shown
Now : 0.9 second until details are shown


Todo: 

- [x] Activating layers in the url on first load
 